### PR TITLE
Better logging information, pass a hash instead of a string as message

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -85,7 +85,7 @@ The optional parameters are:
 
 * `cache` - an instance of your cache solution, can be overwritten in any request
 * `deserializers` - custom methods to deserialize the response body, below more details
-* `logger` - an instance of a logger class that implements `#info` and `#warn` methods
+* `logger` - an instance of a logger class that implements `#info`, `#warn` and `#error` methods
 * `monitor` - to collect metrics about requests, the basis for your instrumentation needs
 * `timeout` - the timeout for all requests, can be overwritten in any request, the default are 3 seconds
 * `user_agent` - if you would like your calls to identify with a specific user agent
@@ -189,6 +189,17 @@ If you want to use a different timeout, you can pass the key `timeout` when init
 #### Custom logger
 
 By default no logging is happening. If you need request logging, you can pass your custom Logger to the key `logger` when initializing the `Connection`. It will write to `logger.info` when starting and when completing a request.
+
+The message passed to the logger is a hash with the following fields:
+
+| Key          | Description                                 |
+|:-------------|:--------------------------------------------|
+| `message`    | indicator if a call was started or finished |
+| `method`     | the HTTP method used                        |
+| `url`        | the requested URL                           |
+| `code`       | HTTP status code                            |
+| `runtime`    | time the request took in ms                 |
+| `user_agent` | the user_agent used to open the connection  |
 
 #### Caching responses
 

--- a/lib/chimera_http_client/request.rb
+++ b/lib/chimera_http_client/request.rb
@@ -16,6 +16,7 @@ module ChimeraHttpClient
       @result
     end
 
+    # rubocop:disable Metrics/MethodLength
     def create(url:, method:, body: nil, options: {}, headers: {})
       request_params = {
         method:          method,
@@ -44,16 +45,35 @@ module ChimeraHttpClient
             completed_at: Time.now.utc.iso8601(3), context: options[:monitoring_context]
           }
         )
-        @options[:logger]&.info("Completed HTTP request: #{method.upcase} #{url} " \
-          "in #{runtime}sec with status code #{response.code}")
+
+        @options[:logger]&.info(
+          {
+            message: "Completed Chimera HTTP Request",
+            method: method.upcase,
+            url: url,
+            code: response.code,
+            runtime: runtime,
+            user_agent: Typhoeus::Config.user_agent,
+          }
+        )
 
         @result = on_complete_handler(response)
       end
 
-      @options[:logger]&.info("Starting HTTP request: #{method.upcase} #{url}")
+      @options[:logger]&.info(
+        {
+          message: "Starting Chimera HTTP Request",
+          method: method.upcase,
+          url: url,
+          code: nil,
+          runtime: 0,
+          user_agent: Typhoeus::Config.user_agent,
+        }
+      )
 
       self
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 


### PR DESCRIPTION
Instead of returning one message string, return a hash which can be printed as string, or used by custom loggers / log-formatters.