### PR TITLE
Do not memoize Request in Connection

### DIFF
--- a/lib/chimera_http_client/connection.rb
+++ b/lib/chimera_http_client/connection.rb
@@ -17,7 +17,7 @@ module ChimeraHttpClient
         monitor: @monitor,
       }
 
-      @request ||= Request.new(options)
+      Request.new(options)
     end
 
     private

--- a/lib/chimera_http_client/version.rb
+++ b/lib/chimera_http_client/version.rb
@@ -1,3 +1,3 @@
 module ChimeraHttpClient
-  VERSION = "1.3.0".freeze
+  VERSION = "1.3.1".freeze
 end


### PR DESCRIPTION
The old behavior could lead to thread safety issues, without offering apparent benefits.