### PR TITLE
Add success? method in Response and Error classes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -329,6 +329,7 @@ The `ChimeraHttpClient::Response` objects have the following interface:
     * code             (http code, should be 200 or 2xx)
     * time             (for monitoring)
     * response         (the full response object, including the request)
+    * success?         (returns the result of response.success?)
     * error?           (returns false)
     * parsed_body      (returns the result of `deserializer[:response].call(body)`)
 
@@ -342,6 +343,7 @@ All errors inherit from `ChimeraHttpClient::Error` and therefore offer the same 
     * body             (alias => message)
     * time             (for monitoring)
     * response         (the full response object, including the request)
+    * success?         (returns the result of response.success?)
     * error?           (returns true)
     * error_class      (e.g. ChimeraHttpClient::NotFoundError)
     * to_s             (information for logging / respects ENV['CHIMERA_HTTP_CLIENT_LOG_REQUESTS'])

--- a/lib/chimera_http_client/error.rb
+++ b/lib/chimera_http_client/error.rb
@@ -14,6 +14,10 @@ module ChimeraHttpClient
       super(response.body)
     end
 
+    def success?
+      response.success?
+    end
+
     def error?
       true
     end

--- a/lib/chimera_http_client/response.rb
+++ b/lib/chimera_http_client/response.rb
@@ -15,6 +15,10 @@ module ChimeraHttpClient
       deserializer.call(body)
     end
 
+    def success?
+      response.success?
+    end
+
     def error?
       false
     end

--- a/spec/chimera_http_client/server/error_spec.rb
+++ b/spec/chimera_http_client/server/error_spec.rb
@@ -2,6 +2,7 @@ require "server_spec_helper"
 
 RSpec.shared_examples "an Error" do
   it { expect(error.error?).to be true }
+  it { expect(error.success?).to be false }
   it { expect(error.code).to eq(failure_code) }
   it { expect(error.class).to eq(described_class) }
   it { expect(error.body).to eq(expected_parsed_body.to_json) }

--- a/spec/chimera_http_client/server/response_spec.rb
+++ b/spec/chimera_http_client/server/response_spec.rb
@@ -2,6 +2,7 @@ require "server_spec_helper"
 
 RSpec.shared_examples "a Response" do
   it { expect(subject.error?).to be false }
+  it { expect(subject.success?).to be true }
   it { expect(subject.class).to eq(ChimeraHttpClient::Response) }
 
   it { expect(subject.body).to eq(response_body.to_json) }


### PR DESCRIPTION
Provide a `success?` method in `Response` and `Error` classes.