### PR TITLE
Update CI Matrix to include recent MRI, JRuby and truffleruby versions

### DIFF
--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest] # macos-latest
-        ruby: ['2.5', '2.6', '2.7', '3.0'] # Due to https://github.com/actions/runner/issues/849, we have to use quotes
+        ruby: ['truffleruby', 'jruby', '2.7', '3.0', '3.1', '3.2', '3.3'] # Due to https://github.com/actions/runner/issues/849, we have to use quotes
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   DisplayCopNames: true
   NewCops: enable # but feel free to disable them below
   SuggestExtensions: false

--- a/README.markdown
+++ b/README.markdown
@@ -18,14 +18,16 @@ The only other runtime dependency is Ruby's latest code loader [**zeitwerk**](ht
 
 ### Ruby version
 
-| Chimera version | Ruby version                       |
-|:----------------|:-----------------------------------|
-| >= 1.4          | >= 2.5 (3.0 compatibility ensured) |
-| >= 1.1          | >= 2.5                             |
-| =  1.0          | >= 2.4, <= 3.0                     |
-| <= 0.5          | >= 2.1, <= 3.0                     |
+| Chimera version | Ruby version                        |
+|:----------------|:------------------------------------|
+| >= 1.6          | >= 2.7 (all 3.x versions supported) |
+| >= 1.4          | >= 2.5 (3.0 compatibility ensured)  |
+| >= 1.1          | >= 2.5                              |
+| =  1.0          | >= 2.4, <= 3.0                      |
+| <= 0.5          | >= 2.1, <= 3.0                      |
 
 The test suite of v1.4 passes on **MRI Ruby** (2.5, 2.6, 2.7, 3.0) and on **JRuby**, but not on **TruffleRuby**.
+The test suite of v1.6 passes on **MRI Ruby** (2.7, 3.0, 3.1, 3.2, 3.3) and on **JRuby** and **TruffleRuby**.
 
 ### ENV variables
 

--- a/chimera_http_client.gemspec
+++ b/chimera_http_client.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "chimera_http_client/version"
 
 Gem::Specification.new do |spec|
-  spec.required_ruby_version = ">= 2.5.0" # without Deserializer's `rescue` in block it would be 2.4.4 (because of zeitwerk)
+  spec.required_ruby_version = ">= 2.7.0" # probably 2.5.0 still works, but 2.7 is the oldest tested version
 
   spec.name          = "chimera_http_client"
   spec.version       = ChimeraHttpClient::VERSION


### PR DESCRIPTION
# Raise required Ruby version to 2.7

The Chimera HTTP Client is now tested against Ruby 3.2 and Ruby 3.3 - but no longer against 2.5 and 2.6.

While those old version are most likely still compatible, they didn't run in the CI anymore. 🤷🏼 